### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:edit, :update, :show]
 
   def index
     @items = Item.order('created_at DESC')
@@ -19,17 +20,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
-    @item = Item.find(params[:id])
-    @item.update(item_params)
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -41,5 +38,9 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :explanation, :category_id, :condition_id, :postage_payer_id, :prefecture_code_id, :days_to_ship_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,15 +1,15 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index,:show]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new
     @item = Item.new
   end
 
-  def create 
+  def create
     @item = Item.create(item_params)
     if @item.save
       redirect_to root_path
@@ -22,7 +22,23 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user.id == @item.user_id
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
   private
+
   def item_params
     params.require(:item).permit(:name, :explanation, :category_id, :condition_id, :postage_payer_id, :prefecture_code_id, :days_to_ship_id, :price, :image).merge(user_id: current_user.id)
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,18 +2,17 @@ class Category < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: 'レディース' },
-    { id: 3, name: 'メンズ'},
-    { id: 4, name: 'ベビー・キッズ'},
+    { id: 3, name: 'メンズ' },
+    { id: 4, name: 'ベビー・キッズ' },
     { id: 5, name: 'インテリア・住まい・小物' },
-    { id: 6, name: '本・音楽・ゲーム'},
-    { id: 7, name: 'おもちゃ・ホビー・グッズ'},
-    { id: 8, name: '家電・スマホ・カメラ'},
-    { id: 9, name: 'スポーツ・レジャー'},
-    { id: 10, name: 'ハンドメイド'},
-    { id: 11, name: 'その他'}
+    { id: 6, name: '本・音楽・ゲーム' },
+    { id: 7, name: 'おもちゃ・ホビー・グッズ' },
+    { id: 8, name: '家電・スマホ・カメラ' },
+    { id: 9, name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,15 +1,14 @@
 class Condition < ActiveHash::Base
-    self.data = [
-      { id: 1, name: '--' },
-      { id: 2, name: '新品・未使用' },
-      { id: 3, name: '未使用に近い'},
-      { id: 4, name: '目立った傷や汚れなし'},
-      { id: 5, name: 'やや傷や汚れあり' },
-      { id: 6, name: '傷や汚れあり'},
-      { id: 7, name: '全体的に状態が悪い'},
-    ]
-  
-    include ActiveHash::Associations
-    has_many :items
-  
+  self.data = [
+    { id: 1, name: '--' },
+    { id: 2, name: '新品・未使用' },
+    { id: 3, name: '未使用に近い' },
+    { id: 4, name: '目立った傷や汚れなし' },
+    { id: 5, name: 'やや傷や汚れあり' },
+    { id: 6, name: '傷や汚れあり' },
+    { id: 7, name: '全体的に状態が悪い' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/days_to_ship.rb
+++ b/app/models/days_to_ship.rb
@@ -3,10 +3,9 @@ class DaysToShip < ActiveHash::Base
     { id: 1, name: '--' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4~7日で発送'}
+    { id: 4, name: '4~7日で発送' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,14 +4,14 @@ class Item < ApplicationRecord
   belongs_to :condition
   belongs_to :postage_payer
   belongs_to :prefecture_code
-  belongs_to :days_to_ship 
+  belongs_to :days_to_ship
 
-has_one :purchase
-belongs_to :user
-has_many   :comments
-has_one_attached :image
+  has_one :purchase
+  belongs_to :user
+  has_many   :comments
+  has_one_attached :image
 
-validates :name, :explanation, :category_id, :condition_id, :postage_payer_id, :prefecture_code_id, :days_to_ship_id, :image, presence: true
-validates :price, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}, format: { with: /\A[0-9]+\z/ }
-validates :category_id, :condition_id, :postage_payer_id, :days_to_ship_id, numericality: { other_than: 1 }
+  validates :name, :explanation, :category_id, :condition_id, :postage_payer_id, :prefecture_code_id, :days_to_ship_id, :image, presence: true
+  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }, format: { with: /\A[0-9]+\z/ }
+  validates :category_id, :condition_id, :postage_payer_id, :days_to_ship_id, numericality: { other_than: 1 }
 end

--- a/app/models/postage_payer.rb
+++ b/app/models/postage_payer.rb
@@ -2,10 +2,9 @@ class PostagePayer < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い（購入者負担）' },
-    { id: 3, name: '送料込み（出品者負担）'},
+    { id: 3, name: '送料込み（出品者負担）' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/prefecture_code.rb
+++ b/app/models/prefecture_code.rb
@@ -1,24 +1,23 @@
 class PrefectureCode < ActiveHash::Base
   self.data = [
-    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
-    {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
-    {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
-    {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
-    {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
-    {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
-    {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
-    {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
-    {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
-    {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
-    {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
-    {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
-    {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
-    {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
-    {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
-    {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+    { id: 1, name: '北海道' }, { id: 2, name: '青森県' }, { id: 3, name: '岩手県' },
+    { id: 4, name: '宮城県' }, { id: 5, name: '秋田県' }, { id: 6, name: '山形県' },
+    { id: 7, name: '福島県' }, { id: 8, name: '茨城県' }, { id: 9, name: '栃木県' },
+    { id: 10, name: '群馬県' }, { id: 11, name: '埼玉県' }, { id: 12, name: '千葉県' },
+    { id: 13, name: '東京都' }, { id: 14, name: '神奈川県' }, { id: 15, name: '新潟県' },
+    { id: 16, name: '富山県' }, { id: 17, name: '石川県' }, { id: 18, name: '福井県' },
+    { id: 19, name: '山梨県' }, { id: 20, name: '長野県' }, { id: 21, name: '岐阜県' },
+    { id: 22, name: '静岡県' }, { id: 23, name: '愛知県' }, { id: 24, name: '三重県' },
+    { id: 25, name: '滋賀県' }, { id: 26, name: '京都府' }, { id: 27, name: '大阪府' },
+    { id: 28, name: '兵庫県' }, { id: 29, name: '奈良県' }, { id: 30, name: '和歌山県' },
+    { id: 31, name: '鳥取県' }, { id: 32, name: '島根県' }, { id: 33, name: '岡山県' },
+    { id: 34, name: '広島県' }, { id: 35, name: '山口県' }, { id: 36, name: '徳島県' },
+    { id: 37, name: '香川県' }, { id: 38, name: '愛媛県' }, { id: 39, name: '高知県' },
+    { id: 40, name: '福岡県' }, { id: 41, name: '佐賀県' }, { id: 42, name: '長崎県' },
+    { id: 43, name: '熊本県' }, { id: 44, name: '大分県' }, { id: 45, name: '宮崎県' },
+    { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,5 +11,5 @@ class User < ApplicationRecord
   validates :nickname, :last_name, :first_name, :last_name_katakana, :first_name_katakana, :birthday, presence: true
   validates :last_name, :first_name, format: { with: /\A[ぁ-んァ-ン一-龥]/ }
   validates :last_name_katakana, :first_name_katakana, format: { with: /\A[ァ-ヶー－]+\z/ }
-  validates :password, format: { with: /\A(?=.?[a-z])(?=.?\d)[a-z\d]+\z/i}
+  validates :password, format: { with: /\A(?=.?[a-z])(?=.?\d)[a-z\d]+\z/i }
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,17 +1,13 @@
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with(model: @item, local: true) do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +19,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +29,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +48,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +69,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_to_ship_id, DaysToShip.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +97,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,12 +137,11 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>
   <% end %>
-
   <footer class="items-sell-footer">
     <ul class="menu">
       <li><a href="#">プライバシーポリシー</a></li>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && @item %>
       <% if current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% elsif @item %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: "items#index"
   devise_for :users
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,17 +2,16 @@ FactoryBot.define do
   factory :item do
     name { Faker::Lorem.sentence }
     explanation { Faker::Lorem.sentence }
-    category_id {2}
-    condition_id {2}
-    postage_payer_id {2}
-    prefecture_code_id {2}
-    days_to_ship_id {2}
-    price {300}
+    category_id { 2 }
+    condition_id { 2 }
+    postage_payer_id { 2 }
+    prefecture_code_id { 2 }
+    days_to_ship_id { 2 }
+    price { 300 }
     association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
   end
- 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     nickname              { Faker::Name.initials(number: 2) }
     email                 { Faker::Internet.free_email }
-    password              { '1a'+Faker::Internet.password(min_length: 6) }
+    password              { '1a' + Faker::Internet.password(min_length: 6) }
     password_confirmation { password }
     last_name             { '山田' }
     first_name            { '太郎' }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,93 +6,93 @@ RSpec.describe Item, type: :model do
   end
 
   describe '商品出品' do
-   context '商品出品がうまくいくとき' do
-    it "全て正しく入力できていれば登録できる" do
-      expect(@item).to be_valid
+    context '商品出品がうまくいくとき' do
+      it '全て正しく入力できていれば登録できる' do
+        expect(@item).to be_valid
+      end
     end
-   end
   end
 
-    context '商品出品がうまくいかないとき' do
-      it "商品名がないと登録できない" do
-        @item.name = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Name can't be blank")
-      end
-      it "商品画像がないと登録できない" do
-        @item.image = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
-      end
-      it "商品説明がないと登録できない" do
-        @item.explanation = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Explanation can't be blank")
-      end
-      it "カテゴリーの情報がないと登録できない" do
-        @item.category_id = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
-      end
-      it "商品の状態がないと登録できない" do
-        @item.condition_id = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Condition can't be blank")
-      end
-      it "配送料の負担についての情報がないと登録できない" do
-        @item.postage_payer_id = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Postage payer can't be blank")
-      end
-      it "発送元の地域についての情報がないと登録できない" do
-        @item.prefecture_code_id = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture code can't be blank")
-      end
-      it "発送までの日数についての情報がないと登録できない" do
-        @item.days_to_ship_id = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Days to ship can't be blank")
-      end
-      it "価格についての情報がないと登録できない" do
-        @item.price = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
-      end
-      it "価格の範囲が¥300~¥9,999,999の間でないと登録できない" do
-        @item.price = 200
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
-      end
-      it "価格が¥10,000,000だと登録できない" do
-        @item.price = 10000000
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
-      end
-      it "価格が半角数値でないと登録できない" do
-        @item.price = "９００"
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Price is invalid")
-      end
-       it "カテゴリーで--を選択すると登録できない" do
-        @item.category_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
-      end
-      it "商品の状態で--を選択すると登録できない" do
-        @item.condition_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
-      end
-      it "配送料の負担で--を選択すると登録できない" do
-        @item.postage_payer_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Postage payer must be other than 1")
-      end
-      it "発送までの日数で--を選択すると登録できない" do
-        @item.days_to_ship_id = 1
-        @item.valid?
-        expect(@item.errors.full_messages).to include("Days to ship must be other than 1")
-      end
+  context '商品出品がうまくいかないとき' do
+    it '商品名がないと登録できない' do
+      @item.name = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Name can't be blank")
+    end
+    it '商品画像がないと登録できない' do
+      @item.image = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Image can't be blank")
+    end
+    it '商品説明がないと登録できない' do
+      @item.explanation = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Explanation can't be blank")
+    end
+    it 'カテゴリーの情報がないと登録できない' do
+      @item.category_id = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Category can't be blank")
+    end
+    it '商品の状態がないと登録できない' do
+      @item.condition_id = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Condition can't be blank")
+    end
+    it '配送料の負担についての情報がないと登録できない' do
+      @item.postage_payer_id = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Postage payer can't be blank")
+    end
+    it '発送元の地域についての情報がないと登録できない' do
+      @item.prefecture_code_id = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Prefecture code can't be blank")
+    end
+    it '発送までの日数についての情報がないと登録できない' do
+      @item.days_to_ship_id = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Days to ship can't be blank")
+    end
+    it '価格についての情報がないと登録できない' do
+      @item.price = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Price can't be blank")
+    end
+    it '価格の範囲が¥300~¥9,999,999の間でないと登録できない' do
+      @item.price = 200
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+    end
+    it '価格が¥10,000,000だと登録できない' do
+      @item.price = 10_000_000
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
+    end
+    it '価格が半角数値でないと登録できない' do
+      @item.price = '９００'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Price is invalid')
+    end
+    it 'カテゴリーで--を選択すると登録できない' do
+      @item.category_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Category must be other than 1')
+    end
+    it '商品の状態で--を選択すると登録できない' do
+      @item.condition_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Condition must be other than 1')
+    end
+    it '配送料の負担で--を選択すると登録できない' do
+      @item.postage_payer_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Postage payer must be other than 1')
+    end
+    it '発送までの日数で--を選択すると登録できない' do
+      @item.days_to_ship_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include('Days to ship must be other than 1')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,88 +1,87 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-
   before do
     @user = FactoryBot.build(:user)
   end
 
   describe 'ユーザー新規登録' do
     context '新規登録がうまくいくとき' do
-    it "全て正しく入力できていれば登録できる" do
-      expect(@user).to be_valid
+      it '全て正しく入力できていれば登録できる' do
+        expect(@user).to be_valid
+      end
     end
-   end
 
-   context '新規登録がうまくいかないとき' do
-    it "ニックネームが必須" do
-      @user.nickname = nil
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Nickname can't be blank")
+    context '新規登録がうまくいかないとき' do
+      it 'ニックネームが必須' do
+        @user.nickname = nil
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      end
+      it 'メールアドレスが必須' do
+        @user.email = nil
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Email can't be blank")
+      end
+      it 'メールアドレスが一意性である' do
+        @user.save
+        another_user = FactoryBot.build(:user, email: @user.email)
+        another_user.valid?
+        expect(another_user.errors.full_messages).to include('Email has already been taken')
+      end
+      it 'メールアドレスに@を含める必要があること' do
+        @user.email = 'aaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Email is invalid')
+      end
+      it 'パスワードが必須であること' do
+        @user.password = nil
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password can't be blank")
+      end
+      it 'パスワードは、半角英数字混合での入力が必須' do
+        @user.password = '111111'
+        @user.password_confirmation = '111111'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is invalid')
+      end
+      it 'passwordが5文字以下であれば登録できないこと' do
+        @user.password = 'abc123'
+        @user.password_confirmation = 'abc123'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is invalid')
+      end
+      it 'パスワードとパスワード（確認用）、値の一致が必須であること' do
+        @user.password = 'abc123'
+        @user.password_confirmation = 'def456'
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      end
+      it 'ユーザー本名は、名字と名前がそれぞれ必須であること' do
+        @user.first_name = nil
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name can't be blank")
+      end
+      it 'ユーザー本名は、全角（漢字・ひらがな・カタカナ）での入力が必須であること' do
+        @user.first_name = 'tarou'
+        @user.valid?
+        expect(@user.errors.full_messages)
+      end
+      it 'ユーザー本名のフリガナは、名字と名前でそれぞれ必須であること' do
+        @user.first_name_katakana = nil
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name katakana can't be blank")
+      end
+      it 'ユーザー本名のフリガナは、全角（カタカナ）での入力が必須であること' do
+        @user.first_name_katakana = 'tarou'
+        @user.valid?
+        expect(@user.errors.full_messages)
+      end
+      it '生年月日が必須であること' do
+        @user.birthday = nil
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+      end
     end
-    it "メールアドレスが必須" do
-      @user.email = nil
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Email can't be blank")
-    end
-    it "メールアドレスが一意性である" do
-      @user.save
-      another_user = FactoryBot.build(:user,email: @user.email)
-      another_user.valid?
-      expect(another_user.errors.full_messages).to include("Email has already been taken")
-    end
-    it "メールアドレスに@を含める必要があること" do
-      @user.email = "aaaaa"
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Email is invalid")
-    end
-    it "パスワードが必須であること" do
-      @user.password = nil
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password can't be blank")
-    end
-    it "パスワードは、半角英数字混合での入力が必須" do
-      @user.password = "111111"
-      @user.password_confirmation = "111111"
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password is invalid")
-    end
-    it "passwordが5文字以下であれば登録できないこと" do
-      @user.password = "abc123"
-      @user.password_confirmation = "abc123"
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password is invalid")
-    end
-    it "パスワードとパスワード（確認用）、値の一致が必須であること" do
-      @user.password = "abc123"
-      @user.password_confirmation = "def456"
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-    end
-    it "ユーザー本名は、名字と名前がそれぞれ必須であること" do
-      @user.first_name = nil
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name can't be blank")
-    end
-    it "ユーザー本名は、全角（漢字・ひらがな・カタカナ）での入力が必須であること" do
-      @user.first_name = "tarou"
-      @user.valid?
-      expect(@user.errors.full_messages)
-    end
-    it "ユーザー本名のフリガナは、名字と名前でそれぞれ必須であること" do
-      @user.first_name_katakana = nil
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name katakana can't be blank")
-    end
-    it "ユーザー本名のフリガナは、全角（カタカナ）での入力が必須であること" do
-      @user.first_name_katakana = "tarou"
-      @user.valid?
-      expect(@user.errors.full_messages)
-    end
-    it "生年月日が必須であること" do
-      @user.birthday = nil
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Birthday can't be blank")
-    end
-  end
   end
 end


### PR DESCRIPTION
#8 商品情報編集機能
ご確認よろしくお願いします。

- 商品情報（商品画像・商品名・商品の状態など）を変更できる（情報を更新できるようにするため）
https://gyazo.com/5f320714d076e9a9d329927ff7e6105f

- 何も編集せずに更新をしても画像無しの商品にならない（画像は編集ページに情報が反映されていないが更新しても元の画像がそのまま表示されるようにするため）
https://gyazo.com/47525bb1b946e8c61f6f3ed6d4462b90

- ログイン状態の出品者だけが商品情報編集ページに遷移できる（出品したユーザーのみが編集を行えるようにするため）
https://gyazo.com/08848f9268903210563a600ee4424a3f

- ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する（出品者以外のユーザーが商品を編集してしまうことを防ぐため）
https://gyazo.com/3bb4e9fc732f4aad5a344887e29e5bff

- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する（ログインしていないユーザーは編集ページに遷移する前にログインさせる必要があるため）
https://gyazo.com/dcc87918a7204a2cff6707edc9c42a94

- 商品出品時とほぼ同じ見た目で商品情報編集機能が実装されている（出品時と同じ項目が表示されていないと、編集する時にどこの項目を編集したら良いか分かりにくくなってしまうため）
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される（編集が必要な項目だけ更新すれば済むようにするため）
https://gyazo.com/47525bb1b946e8c61f6f3ed6d4462b90

- エラーハンドリングができている（適切ではない値がそのまま保存されてしまうのを防ぐため）
- エラーメッセージの出力は、商品情報編集ページにて行う（エラーをすぐに修正できるように、どこの項目がエラーになっているのかをすぐに確認できるようにするため）
https://i.gyazo.com/39ed45f932f93b40419d65028a519528.mp4

※購入機能実装後に確認
- 出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
- ログアウト状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、ログインページに遷移すること